### PR TITLE
Added a step to force stop the EC2 instance if it gets stuck stopping.

### DIFF
--- a/Documents/Automation/StopInstance/Documents/aws-StopEC2Instance.json
+++ b/Documents/Automation/StopInstance/Documents/aws-StopEC2Instance.json
@@ -17,9 +17,20 @@
     {
       "name": "stopInstances",
       "action": "aws:changeInstanceState",
+      "onFailure": "Continue",
       "inputs": {
         "InstanceIds": "{{ InstanceId }}",
         "DesiredState": "stopped"
+      }
+    },
+    {
+      "name": "forceStopInstances",
+      "action": "aws:changeInstanceState",
+      "inputs": {
+        "InstanceIds": "{{ InstanceId }}",
+        "CheckStateOnly": false,
+        "DesiredState": "stopped",
+        "Force": true
       }
     }
   ]

--- a/Documents/Automation/StopInstanceWithApproval/Documents/aws-StopEC2InstanceWithApproval.json
+++ b/Documents/Automation/StopInstanceWithApproval/Documents/aws-StopEC2InstanceWithApproval.json
@@ -36,9 +36,20 @@
     {
       "name": "stopInstances",
       "action": "aws:changeInstanceState",
+      "onFailure": "Continue",
       "inputs": {
         "InstanceIds": "{{ InstanceId }}",
         "DesiredState": "stopped"
+      }
+    },
+    {
+      "name": "forceStopInstances",
+      "action": "aws:changeInstanceState",
+      "inputs": {
+        "InstanceIds": "{{ InstanceId }}",
+        "CheckStateOnly": false,
+        "DesiredState": "stopped",
+        "Force": true
       }
     }
   ]


### PR DESCRIPTION
If you have stopped your Amazon EBS-backed instance and it appears stuck in the stopping state, there may be an issue with the underlying host computer [1].
Therefore, we should attempt a force stop if the first attempts fails.

[1] https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/TroubleshootingInstancesStopping.html