### PR TITLE
Parameterize polling interval time

### DIFF
--- a/Documents/Automation/Testing/ssm_testing.py
+++ b/Documents/Automation/Testing/ssm_testing.py
@@ -43,7 +43,7 @@ class CFNTester(object):
             params = []
 
         self.delete_stack()
-        LOGGER.info('Creating stack %s', self.stack_name)
+        LOGGER.info('Creating stack %s' % self.stack_name)
         stack = self.cfn_client.create_stack(
             StackName=self.stack_name,
             TemplateBody=self.template_body,
@@ -88,7 +88,7 @@ class CFNTester(object):
             # Nothing to do here
             return True
         else:
-            LOGGER.info('Deleting existing stack %s', self.stack_name)
+            LOGGER.info('Deleting existing stack %s' % self.stack_name)
             self.cfn_client.delete_stack(StackName=self.stack_name)
             while self.is_stack_present() is True:
                 LOGGER.info('Waiting %d seconds before checking again for successful stack deletion' % poll_interval)


### PR DESCRIPTION
Due to the long running nature of automation testing, I typically enable logging to stdout in order to see test progression, however, far too many lines are logged to the console because the polling interval for various state checks is hard-coded to 10 seconds. I find that this is far too short for long running actions, particularly automation executions, and am of the opinion that the user (test author) should able to configure this value to suit with the expected length of the action whose state is being checked. The new keyword argument has a default value equal to the original, hard-coded value so there is no functional impact for existing users and their tests.

In [logging.debug](https://docs.python.org/3/library/logging.html#logging.debug) (and all other logging message methods such as info), *args is implied to be formatting args for %, however, I feel this only makes the logging lines confusing to read because the args are inconsistent with % string format lines used elsewhere (i.e. in get_automation_role). This doesn't introduce any functional change, but makes the code slightly easier to read.