### PR TITLE
update resize-instance to clear cfn stack after failure

### DIFF
--- a/Documents/Automation/ResizeInstance/Documents/aws-ResizeInstance.json
+++ b/Documents/Automation/ResizeInstance/Documents/aws-ResizeInstance.json
@@ -47,6 +47,7 @@
     {
       "name": "stopInstances",
       "action": "aws:changeInstanceState",
+      "onFailure": "step:deleteCloudFormationTemplate",
       "inputs": {
         "InstanceIds": ["{{InstanceId}}"],
         "DesiredState": "stopped"

--- a/Documents/Automation/ResizeInstance/Documents/aws-ResizeInstance.json
+++ b/Documents/Automation/ResizeInstance/Documents/aws-ResizeInstance.json
@@ -56,6 +56,7 @@
     {
       "name": "resizeInstance",
       "action": "aws:invokeLambdaFunction",
+      "onFailure": "step:deleteCloudFormationTemplate",
       "inputs": {
         "FunctionName": "ResizeInstanceLambda-{{automation:EXECUTION_ID}}",
         "Payload":  "{\"InstanceId\": \"{{InstanceId}}\", \"InstanceType\": \"{{InstanceType}}\"}"
@@ -64,6 +65,7 @@
     {
       "name": "startInstances",
       "action": "aws:changeInstanceState",
+      "onFailure": "step:deleteCloudFormationTemplate",
       "inputs": {
         "InstanceIds": ["{{InstanceId}}"],
         "DesiredState": "running"


### PR DESCRIPTION
Description of changes:

Delete the CloudFormation stack after a failed resize (for instance, because a wrong instance id was provided)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
